### PR TITLE
Add nil read for byte array

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -249,6 +249,10 @@ func (d *Decoder) readStringLength() (uint32, error) {
 }
 
 func (d *Decoder) ReadByteArray() ([]byte, error) {
+	isNil, err := d.IsNextNil()
+	if isNil || err != nil {
+		return nil, err
+	}
 	binLen, err := d.readBinLength()
 	if err != nil {
 		return nil, err
@@ -471,7 +475,7 @@ type ReadError struct {
 }
 
 func NewReadError(s string) ReadError {
-	return ReadError{ message: s }
+	return ReadError{message: s}
 }
 
 func (e ReadError) Error() string {


### PR DESCRIPTION
The encoder will write nil when the array length is zero https://github.com/wasmCloud/tinygo-msgpack/blob/main/encoder.go#L140.
But the decoder does not handle this case.